### PR TITLE
add seaborn as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='smapp-toolkit',
           'smappPy>=0.1.16',
           'networkx>=1.9.1',
           'pandas>=0.16.1',
-          'simplejson'
+          'simplejson',
+          'seaborn'
       ]
      )


### PR DESCRIPTION
Hi. I was trying to run a script with smapp-toolkit and it returned this warning:

![screen shot 2015-07-31 at 5 31 19 pm](https://cloud.githubusercontent.com/assets/5566509/9018225/bb259c1e-37aa-11e5-8db0-1d363debae33.png)

It looks like seaborn was missing as a dependency, and I added it to the install_requires in setup.py. Hopefully this code works on your end as well. Thanks!
